### PR TITLE
Add install-opendaq-action with package installation support

### DIFF
--- a/.github/workflows/test-bash-framework.yml
+++ b/.github/workflows/test-bash-framework.yml
@@ -3,9 +3,11 @@ name: Test Bash Framework
 on:
   push:
     branches: [main]
-    paths-ignore: [ 'docs/**', '**/*.md' ]
+    paths: [ 'scripts-demo/**', 'tests/shell/bash/**' ]
+    paths-ignore: [ 'tests/shell/bash/suites/**' ]
   pull_request:
-    paths-ignore: [ 'docs/**', '**/*.md' ]
+    paths: [ 'scripts-demo/**', 'tests/shell/bash/**' ]
+    paths-ignore: [ 'tests/shell/bash/suites/**' ]
   workflow_dispatch:
 
 jobs:
@@ -21,14 +23,8 @@ jobs:
           - os: ubuntu-latest
             shell-name: bash
             shell-cmd: bash
-          - os: ubuntu-latest
-            shell-name: zsh
-            shell-cmd: zsh
           
-          # macOS - bash and zsh
-          - os: macos-latest
-            shell-name: bash
-            shell-cmd: bash
+          # macOS - zsh
           - os: macos-latest
             shell-name: zsh
             shell-cmd: zsh
@@ -41,13 +37,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
-      - name: Install zsh (Ubuntu only)
-        if: matrix.os == 'ubuntu-latest' && matrix.shell-name == 'zsh'
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y zsh
       
       - name: Run demo tests (excluding intentional failures)
         shell: bash

--- a/.github/workflows/test-bash-framework.yml
+++ b/.github/workflows/test-bash-framework.yml
@@ -4,10 +4,8 @@ on:
   push:
     branches: [main]
     paths: [ 'scripts-demo/**', 'tests/shell/bash/**' ]
-    paths-ignore: [ 'tests/shell/bash/suites/**' ]
   pull_request:
     paths: [ 'scripts-demo/**', 'tests/shell/bash/**' ]
-    paths-ignore: [ 'tests/shell/bash/suites/**' ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-bash-scripts.yml
+++ b/.github/workflows/test-bash-scripts.yml
@@ -3,9 +3,9 @@ name: Test Bash Scripts
 on:
   push:
     branches: [main]
-    paths-ignore: [ 'docs/**', '**/*.md' ]
+    paths: [ 'scripts/**', 'tests/shell/bash/**' ]
   pull_request:
-    paths-ignore: [ 'docs/**', '**/*.md' ]
+    paths: [ 'scripts/**', 'tests/shell/bash/**' ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-bash-scripts.yml
+++ b/.github/workflows/test-bash-scripts.yml
@@ -34,7 +34,8 @@ jobs:
         working-directory: tests/shell/bash
         run: |
           ./test-runner.sh \
-            --fail-fast true
+            --fail-fast true \
+            --verbose
       
       - name: Test results summary
         if: always()

--- a/.github/workflows/test-framework-compose-filename-manual.yml
+++ b/.github/workflows/test-framework-compose-filename-manual.yml
@@ -1,0 +1,57 @@
+name: "Call action manually: framework compose filename"
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: "Runner to use (e.g. ubuntu-latest, ubuntu-22.04, windows-latest, etc)"
+        type: string
+        required: false
+        default: ubuntu-latest
+      version:
+        description: 'OpenDAQ version (if not set, resolves to latest from openDAQ/openDAQ)'
+        required: false
+      platform:
+        description: 'Target platform (if not set, auto-detected)'
+        required: false
+      packaging:
+        description: 'Packaging format for cpack (if not set, uses runner OS name)'
+        required: false
+
+jobs:
+  test-compose-filename-manually:
+    runs-on: ${{ inputs.runner }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Compose openDAQ framework filename
+      id: call-framework-compose-filename
+      uses: ./framework-compose-filename
+      with:
+        version: ${{ inputs.version }}
+        platform: ${{ inputs.platform }}
+        packaging: ${{ inputs.packaging }}
+    
+    - name: Display Results
+      shell: bash
+      run: |
+        echo "╔══════════════════════════════════════════════════════════════════════════════╗"
+        echo "║                     Package Filename Composition Results                     ║"
+        echo "╠══════════════════════════════════════════════════════════════════════════════╣"
+        echo "║ 🏷️  Version (full):    ${{ steps.call-framework-compose-filename.outputs.version }}"
+        echo "║    ├─ Major:           ${{ steps.call-framework-compose-filename.outputs.version-major }}"
+        echo "║    ├─ Minor:           ${{ steps.call-framework-compose-filename.outputs.version-minor }}"
+        echo "║    ├─ Patch:           ${{ steps.call-framework-compose-filename.outputs.version-patch }}"
+        echo "║    ├─ Suffix:          ${{ steps.call-framework-compose-filename.outputs.version-suffix || '*** NOT SET ***' }}"
+        echo "║    └─ Hash:            ${{ steps.call-framework-compose-filename.outputs.version-hash || '*** NOT SET ***' }}"
+        echo "╠══════════════════════════════════════════════════════════════════════════════╣"
+        echo "║ 🖥️  Platform (full):   ${{ steps.call-framework-compose-filename.outputs.platform }}"
+        echo "║    ├─ OS Name:         ${{ steps.call-framework-compose-filename.outputs.platform-os-name }}"
+        echo "║    ├─ OS Version:      ${{ steps.call-framework-compose-filename.outputs.platform-os-version }}"
+        echo "║    └─ Architecture:    ${{ steps.call-framework-compose-filename.outputs.platform-os-arch }}"
+        echo "╠══════════════════════════════════════════════════════════════════════════════╣"
+        echo "║ 📦 Packaging:          ${{ steps.call-framework-compose-filename.outputs.packaging }}"
+        echo "╠══════════════════════════════════════════════════════════════════════════════╣"
+        echo "║ 📄 Filename:           ${{ steps.call-framework-compose-filename.outputs.filename }}"
+        echo "╚══════════════════════════════════════════════════════════════════════════════╝"

--- a/.github/workflows/test-framework-download-release-manual.yml
+++ b/.github/workflows/test-framework-download-release-manual.yml
@@ -1,0 +1,82 @@
+name: Test Download Release Asset
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner-os:
+        description: 'Runner OS to use'
+        required: true
+        type: string
+        default: 'ubuntu-latest'
+      
+      version:
+        description: 'Release version (e.g., v3.20.4) or "latest"'
+        required: false
+        type: string
+        default: 'latest'
+      
+      platform:
+        description: 'Target platform (e.g., ubuntu22.04-x86_64, win64) or leave empty for auto-detect'
+        required: false
+        type: string
+        default: ''
+      
+      packaging:
+        description: 'Package format override (e.g., deb, exe, tar.gz, zip) or leave empty for auto-detect'
+        required: false
+        type: string
+        default: ''
+      
+      asset-pattern:
+        description: 'Custom glob pattern to filter assets (overrides auto-detection)'
+        required: false
+        type: string
+        default: ''
+      
+      output-dir:
+        description: 'Output directory for downloaded assets (leave empty for runner.temp)'
+        required: false
+        type: string
+        default: ''
+      
+      verbose:
+        description: 'Enable verbose output'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  download-release:
+    name: Download on ${{ inputs.runner-os }}
+    runs-on: ${{ inputs.runner-os }}
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Download OpenDAQ release asset
+        id: download
+        uses: ./framework-download-release
+        with:
+          version: ${{ inputs.version }}
+          platform: ${{ inputs.platform }}
+          packaging: ${{ inputs.packaging }}
+          asset-pattern: ${{ inputs.asset-pattern }}
+          output-dir: ${{ inputs.output-dir }}
+          verbose: ${{ inputs.verbose }}
+      
+      - name: Display results
+        shell: bash
+        run: |
+          echo "=== Download Results ==="
+          echo ""
+          echo "📦 Asset: ${{ steps.download.outputs.asset-filename }}"
+          echo "📍 Path: ${{ steps.download.outputs.asset }}"
+          echo "📂 Directory: ${{ steps.download.outputs.asset-dir }}"
+          echo ""
+          echo "🏷️  Version: ${{ steps.download.outputs.version }}"
+          echo "🖥️  Platform: ${{ steps.download.outputs.platform }}"
+          echo "📦 Packaging: ${{ steps.download.outputs.packaging }}"
+          echo ""
+          echo "📊 Size: ${{ steps.download.outputs.asset-filesize }} bytes"
+          echo "🔐 SHA256: ${{ steps.download.outputs.asset-checksum }}"

--- a/framework-install/README.md
+++ b/framework-install/README.md
@@ -1,0 +1,122 @@
+# Install openDAQ Framework Package
+
+This action installs the openDAQ framework package on Windows and Linux runners.
+
+## Usage
+
+```yaml
+- uses: openDAQ/install-opendaq-action@v1
+  with:
+    # Full path to the openDAQ framework package file
+    # Required
+    framework-filename: ''
+```
+
+## Inputs
+
+### `framework-filename`
+
+**Required** Full path to the openDAQ framework package file.
+
+- **Windows**: Path to `.exe` installer (e.g., `opendaq-v3.20.4-win64.exe`)
+- **Linux**: Path to `.deb` package (e.g., `opendaq-v3.20.4-ubuntu20.04-x86_64.deb`)
+
+## Supported Platforms
+
+- ✅ Windows (via `.exe` installer)
+- ✅ Linux (via `.deb` package)
+- ❌ macOS (not yet supported)
+
+## Examples
+
+### Install from downloaded artifact
+
+```yaml
+steps:
+  - name: Download openDAQ package
+    uses: actions/download-artifact@v4
+    with:
+      name: opendaq-package
+      path: ${{ runner.temp }}/packages
+
+  - name: Install openDAQ
+    uses: openDAQ/install-opendaq-action@v1
+    with:
+      framework-filename: ${{ runner.temp }}/packages/opendaq-v3.20.4-win64.exe
+```
+
+### Install from release
+
+```yaml
+steps:
+  - name: Download openDAQ release
+    run: |
+      curl -L -o ${{ runner.temp }}/opendaq.deb \
+        https://github.com/openDAQ/openDAQ/releases/download/v3.20.4/opendaq-v3.20.4-ubuntu22.04-x86_64.deb
+
+  - name: Install openDAQ
+    uses: openDAQ/install-opendaq-action@v1
+    with:
+      framework-filename: ${{ runner.temp }}/opendaq.deb
+```
+
+### Matrix build with multiple platforms
+
+```yaml
+jobs:
+  test:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            package: opendaq-v3.20.4-ubuntu22.04-x86_64.deb
+          - os: ubuntu-20.04
+            package: opendaq-v3.20.4-ubuntu20.04-x86_64.deb
+          - os: windows-2022
+            package: opendaq-v3.20.4-win64.exe
+    
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+      - name: Download package
+        run: |
+          # Download logic here
+          # Save to ${{ runner.temp }}/${{ matrix.package }}
+
+      - name: Install openDAQ
+        uses: openDAQ/install-opendaq-action@v1
+        with:
+          framework-filename: ${{ runner.temp }}/${{ matrix.package }}
+
+      - name: Verify installation
+        run: |
+          # Your verification commands
+```
+
+## How It Works
+
+### Windows
+1. Runs the `.exe` installer with `/S` (silent) flag
+2. Waits for installation to complete
+3. Adds `C:\Program Files\openDAQ\bin` to `PATH`
+4. Verifies exit code
+
+### Linux
+1. Uses `dpkg -i` with `sudo` to install the `.deb` package
+2. Package dependencies are automatically resolved
+
+## Post-Installation
+
+After successful installation:
+
+- **Windows**: The openDAQ binaries are added to `PATH`
+- **Linux**: The openDAQ libraries are installed system-wide
+
+You can immediately use openDAQ commands and libraries in subsequent steps.
+
+## Error Handling
+
+The action will fail if:
+- The package file doesn't exist
+- Installation returns a non-zero exit code
+- The runner OS is not supported (macOS)

--- a/framework-install/action.yml
+++ b/framework-install/action.yml
@@ -1,0 +1,50 @@
+name: Install openDAQ framework package
+
+inputs:
+  framework-filename:
+    required: true
+    description: Full path to the openDAQ framework package file
+
+runs:
+  using: composite
+
+  steps:
+    - name: Convert path for Windows
+      if: runner.os == 'Windows'
+      id: windows-path
+      shell: bash
+      run: |
+        # Convert Unix-style path to Windows-style
+        windowsPath=$(cygpath -w "${{ inputs.framework-filename }}")
+        echo "path=$windowsPath" >> $GITHUB_OUTPUT
+
+    - name: Install openDAQ framework package (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $packagePath = "${{ steps.windows-path.outputs.path }}"
+        Write-Host "Installing from: $packagePath"
+
+        $process = Start-Process -FilePath $packagePath -ArgumentList "/S" -Wait -NoNewWindow -PassThru
+        if ($process.ExitCode -eq 0) {
+            Write-Host "OpenDAQ installed successfully, updating PATH..."
+            $openDAQBin = "C:\Program Files\openDAQ\bin"
+            Add-Content -Path $env:GITHUB_ENV -Value "PATH=$openDAQBin`;$env:PATH"
+            Write-Host $env:PATH
+        }
+        else {
+            Write-Host "OpenDAQ installation failed with exit code $($process.ExitCode)"
+            exit $process.ExitCode
+        }
+
+    - name: Install openDAQ framework package (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: sudo dpkg -i "${{ inputs.framework-filename }}"
+
+    - name: Unsupported runner OS
+      if: runner.os != 'Windows' && runner.os != 'Linux'
+      shell: bash
+      run: |
+        echo "Install openDAQ is not supported for ${{ runner.os }}"
+        exit 1

--- a/tests/shell/bash/core/filter.sh
+++ b/tests/shell/bash/core/filter.sh
@@ -62,16 +62,28 @@ __daq_tests_filter_matches_any() {
     local test_name="$2"
     local patterns_array_name="$3"
     
-    eval "
-    for __pattern in \"\${${patterns_array_name}[@]}\"; do
-        __daq_tests_filter_parse_pattern \"\${__pattern}\"
+    # Get array size first to handle empty arrays
+    local array_size
+    array_size=$(eval "echo \${#${patterns_array_name}[@]}")
+    
+    if [[ "${array_size}" -eq 0 ]]; then
+        return 1
+    fi
+    
+    # Copy array to local variable using eval - single eval, safe approach
+    local -a patterns
+    eval "patterns=(\"\${${patterns_array_name}[@]}\")"
+    
+    # Clean iteration without eval
+    local pattern
+    for pattern in "${patterns[@]}"; do
+        __daq_tests_filter_parse_pattern "${pattern}"
         
-        if __daq_tests_match_pattern \"\${suite_name}\" \"\${__DAQ_TESTS_PATTERN_SUITE}\" && \
-           __daq_tests_match_pattern \"\${test_name}\" \"\${__DAQ_TESTS_PATTERN_TEST}\"; then
+        if __daq_tests_match_pattern "${suite_name}" "${__DAQ_TESTS_PATTERN_SUITE}" && \
+           __daq_tests_match_pattern "${test_name}" "${__DAQ_TESTS_PATTERN_TEST}"; then
             return 0
         fi
     done
-    "
     
     return 1
 }

--- a/tests/shell/bash/suites/test-platform-format-api.sh
+++ b/tests/shell/bash/suites/test-platform-format-api.sh
@@ -1,0 +1,389 @@
+#!/usr/bin/env bash
+# test-platform-format-api.sh - API tests for platform-format.sh public functions
+#
+# Tests all public API functions (daq_platform_*):
+# - daq_platform_validate
+# - daq_platform_parse
+# - daq_platform_extract
+# - daq_platform_compose
+# - daq_platform_list
+# - daq_platform_detect
+
+# Source the script under test
+source "${__DAQ_TESTS_SCRIPTS_DIR}/platform-format.sh"
+
+test-validate-ubuntu-valid() {
+    daq_platform_validate "ubuntu20.04-x86_64" >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for valid Ubuntu platform" || return 1
+    return 0
+}
+
+test-validate-debian-valid() {
+    daq_platform_validate "debian11-arm64" >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for valid Debian platform" || return 1
+    return 0
+}
+
+test-validate-macos-valid() {
+    daq_platform_validate "macos14-arm64" >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for valid macOS platform" || return 1
+    return 0
+}
+
+test-validate-windows-valid() {
+    daq_platform_validate "win64" >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for valid Windows platform" || return 1
+    return 0
+}
+
+test-validate-invalid-platform() {
+    daq_platform_validate "invalid-platform" >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "validate should fail for invalid platform" || return 1
+    return 0
+}
+
+test-validate-is-unix-true() {
+    daq_platform_validate "ubuntu20.04-x86_64" --is-unix >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "Ubuntu should be Unix" || return 1
+    return 0
+}
+
+test-validate-is-unix-false() {
+    daq_platform_validate "win64" --is-unix >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "Windows should not be Unix" || return 1
+    return 0
+}
+
+test-validate-is-linux-true() {
+    daq_platform_validate "ubuntu20.04-x86_64" --is-linux >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "Ubuntu should be Linux" || return 1
+    return 0
+}
+
+test-validate-is-linux-false() {
+    daq_platform_validate "macos14-arm64" --is-linux >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "macOS should not be Linux" || return 1
+    return 0
+}
+
+test-validate-is-ubuntu-true() {
+    daq_platform_validate "ubuntu20.04-x86_64" --is-ubuntu >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "Should identify Ubuntu" || return 1
+    return 0
+}
+
+test-validate-is-debian-true() {
+    daq_platform_validate "debian11-arm64" --is-debian >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "Should identify Debian" || return 1
+    return 0
+}
+
+test-validate-is-macos-true() {
+    daq_platform_validate "macos14-arm64" --is-macos >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "Should identify macOS" || return 1
+    return 0
+}
+
+test-validate-is-win-true() {
+    daq_platform_validate "win64" --is-win >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "Should identify Windows" || return 1
+    return 0
+}
+
+test-parse-ubuntu-all-components() {
+    local result
+    result=$(daq_platform_parse "ubuntu20.04-x86_64")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "ubuntu 20.04 x86_64" "$result" "Ubuntu parse result mismatch" || return 1
+    return 0
+}
+
+test-parse-debian-all-components() {
+    local result
+    result=$(daq_platform_parse "debian11-arm64")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "debian 11 arm64" "$result" "Debian parse result mismatch" || return 1
+    return 0
+}
+
+test-parse-macos-all-components() {
+    local result
+    result=$(daq_platform_parse "macos14-arm64")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "macos 14 arm64" "$result" "macOS parse result mismatch" || return 1
+    return 0
+}
+
+test-parse-windows-all-components() {
+    local result
+    result=$(daq_platform_parse "win64")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "win 64" "$result" "Windows parse result mismatch" || return 1
+    return 0
+}
+
+test-parse-extract-os-name() {
+    local result
+    result=$(daq_platform_parse "ubuntu20.04-x86_64" --os-name)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "ubuntu" "$result" "OS name extraction mismatch" || return 1
+    return 0
+}
+
+test-parse-extract-os-version() {
+    local result
+    result=$(daq_platform_parse "ubuntu20.04-x86_64" --os-version)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "20.04" "$result" "OS version extraction mismatch" || return 1
+    return 0
+}
+
+test-parse-extract-os-arch() {
+    local result
+    result=$(daq_platform_parse "ubuntu20.04-x86_64" --os-arch)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "x86_64" "$result" "OS arch extraction mismatch" || return 1
+    return 0
+}
+
+test-parse-windows-no-version() {
+    local result
+    result=$(daq_platform_parse "win64" --os-version)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_empty "$result" "Windows should have no version" || return 1
+    return 0
+}
+
+test-parse-invalid-platform() {
+    local result
+    result=$(daq_platform_parse "invalid-platform" 2>&1)
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "parse should fail for invalid platform" || return 1
+    return 0
+}
+
+test-extract-ubuntu() {
+    local result
+    result=$(daq_platform_extract "ubuntu20.04-x86_64" --os-name)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "extract should succeed" || return 1
+    daq_assert_equals "ubuntu" "$result" "Extract should work like parse" || return 1
+    return 0
+}
+
+test-extract-multiple-components() {
+    local result
+    result=$(daq_platform_extract "debian11-arm64" --os-name --os-arch)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "extract should succeed" || return 1
+    daq_assert_contains "debian" "$result" "Should contain OS name" || return 1
+    daq_assert_contains "arm64" "$result" "Should contain architecture" || return 1
+    return 0
+}
+
+test-compose-ubuntu() {
+    local result
+    result=$(daq_platform_compose --os-name ubuntu --os-version 20.04 --os-arch x86_64)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "ubuntu20.04-x86_64" "$result" "Ubuntu compose result mismatch" || return 1
+    return 0
+}
+
+test-compose-debian() {
+    local result
+    result=$(daq_platform_compose --os-name debian --os-version 11 --os-arch arm64)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "debian11-arm64" "$result" "Debian compose result mismatch" || return 1
+    return 0
+}
+
+test-compose-macos() {
+    local result
+    result=$(daq_platform_compose --os-name macos --os-version 14 --os-arch arm64)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "macos14-arm64" "$result" "macOS compose result mismatch" || return 1
+    return 0
+}
+
+test-compose-windows() {
+    local result
+    result=$(daq_platform_compose --os-name win --os-arch 64)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "win64" "$result" "Windows compose result mismatch" || return 1
+    return 0
+}
+
+test-compose-missing-os-name() {
+    local result
+    result=$(daq_platform_compose --os-version 20.04 --os-arch x86_64 2>&1)
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "compose should fail without os-name" || return 1
+    return 0
+}
+
+test-compose-missing-os-arch() {
+    local result
+    result=$(daq_platform_compose --os-name ubuntu --os-version 20.04 2>&1)
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "compose should fail without os-arch" || return 1
+    return 0
+}
+
+test-compose-linux-missing-version() {
+    local result
+    result=$(daq_platform_compose --os-name ubuntu --os-arch x86_64 2>&1)
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "compose should fail without version for Linux" || return 1
+    return 0
+}
+
+test-compose-invalid-combination() {
+    local result
+    result=$(daq_platform_compose --os-name ubuntu --os-version 99.99 --os-arch x86_64 2>&1)
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "compose should fail for invalid version" || return 1
+    return 0
+}
+
+test-list-returns-platforms() {
+    local result
+    result=$(daq_platform_list)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "list should succeed" || return 1
+    daq_assert_not_empty "$result" "list should return platforms" || return 1
+    return 0
+}
+
+test-list-contains-ubuntu() {
+    local result
+    result=$(daq_platform_list)
+    
+    daq_assert_contains "ubuntu20.04-x86_64" "$result" "Should contain Ubuntu 20.04 x86_64" || return 1
+    return 0
+}
+
+test-list-contains-debian() {
+    local result
+    result=$(daq_platform_list)
+    
+    daq_assert_contains "debian11-arm64" "$result" "Should contain Debian 11 ARM64" || return 1
+    return 0
+}
+
+test-list-contains-macos() {
+    local result
+    result=$(daq_platform_list)
+    
+    daq_assert_contains "macos14-arm64" "$result" "Should contain macOS 14 ARM64" || return 1
+    return 0
+}
+
+test-list-contains-windows() {
+    local result
+    result=$(daq_platform_list)
+    
+    daq_assert_contains "win64" "$result" "Should contain Windows 64-bit" || return 1
+    daq_assert_contains "win32" "$result" "Should contain Windows 32-bit" || return 1
+    return 0
+}
+
+test-list-platform-count() {
+    local count
+    count=$(daq_platform_list | wc -l)
+    
+    # Should have multiple platforms (exact count may vary)
+    daq_assert_greater_than 30 "$count" "Should have more than 50 platforms" || return 1
+    return 0
+}
+
+test-detect-returns-valid-platform() {
+    local result
+    result=$(daq_platform_detect 2>/dev/null)
+    local exit_code=$?
+    
+    # Detection may fail on some systems, so we check if it succeeds
+    if [[ $exit_code -eq 0 ]]; then
+        daq_assert_not_empty "$result" "detect should return platform" || return 1
+        
+        # Validate that detected platform is valid
+        daq_platform_validate "$result" >/dev/null 2>&1
+        daq_assert_success $? "detected platform should be valid" || return 1
+    fi
+    
+    return 0
+}
+
+test-detect-platform-components() {
+    local result
+    result=$(daq_platform_detect 2>/dev/null)
+    local exit_code=$?
+    
+    # Detection may fail on some systems
+    if [[ $exit_code -eq 0 ]]; then
+        # Should be able to parse detected platform
+        local os_name
+        os_name=$(daq_platform_parse "$result" --os-name 2>/dev/null)
+        
+        daq_assert_not_empty "$os_name" "detected platform should have OS name" || return 1
+    fi
+    
+    return 0
+}

--- a/tests/shell/bash/suites/test-platform-format-cli.sh
+++ b/tests/shell/bash/suites/test-platform-format-cli.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# test-platform-format-cli.sh - CLI tests for platform-format.sh
+#
+# Tests the command-line interface of platform-format.sh:
+# - Help and usage
+# - detect command
+# - validate command
+# - parse/extract command
+# - compose command
+# - --list-platforms flag
+
+# CLI script path
+PLATFORM_FORMAT_CLI="${__DAQ_TESTS_SCRIPTS_DIR}/platform-format.sh"
+
+test-cli-help-global() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" 2>&1)  # No command
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "Should exit with error"
+    daq_assert_contains "Usage:" "$result" "Should show usage"
+    daq_assert_contains "Commands:" "$result" "Should show commands"
+}
+
+test-cli-detect-current-platform() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" detect 2>/dev/null)
+    local exit_code=$?
+    
+    # Detection may fail on some systems
+    if [[ $exit_code -eq 0 ]]; then
+        daq_assert_not_empty "$result" "detect should return platform" || return 1
+    fi
+    
+    return 0
+}
+
+test-cli-validate-ubuntu-valid() {
+    "${PLATFORM_FORMAT_CLI}" validate "ubuntu20.04-x86_64" >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for valid Ubuntu" || return 1
+    return 0
+}
+
+test-cli-validate-debian-valid() {
+    "${PLATFORM_FORMAT_CLI}" validate "debian11-arm64" >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for valid Debian" || return 1
+    return 0
+}
+
+test-cli-validate-macos-valid() {
+    "${PLATFORM_FORMAT_CLI}" validate "macos14-arm64" >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for valid macOS" || return 1
+    return 0
+}
+
+test-cli-validate-windows-valid() {
+    "${PLATFORM_FORMAT_CLI}" validate "win64" >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for valid Windows" || return 1
+    return 0
+}
+
+test-cli-validate-invalid() {
+    "${PLATFORM_FORMAT_CLI}" validate "invalid-platform" >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "validate should fail for invalid platform" || return 1
+    return 0
+}
+
+test-cli-validate-is-unix() {
+    "${PLATFORM_FORMAT_CLI}" validate "ubuntu20.04-x86_64" --is-unix >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "Ubuntu should be Unix" || return 1
+    return 0
+}
+
+test-cli-validate-is-linux() {
+    "${PLATFORM_FORMAT_CLI}" validate "debian11-arm64" --is-linux >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "Debian should be Linux" || return 1
+    return 0
+}
+
+test-cli-validate-is-macos() {
+    "${PLATFORM_FORMAT_CLI}" validate "macos14-arm64" --is-macos >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "Should identify macOS" || return 1
+    return 0
+}
+
+test-cli-validate-is-win() {
+    "${PLATFORM_FORMAT_CLI}" validate "win64" --is-win >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "Should identify Windows" || return 1
+    return 0
+}
+
+test-cli-parse-ubuntu() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" parse "ubuntu20.04-x86_64")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "ubuntu 20.04 x86_64" "$result" "Ubuntu parse result mismatch" || return 1
+    return 0
+}
+
+test-cli-parse-debian() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" parse "debian11-arm64")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "debian 11 arm64" "$result" "Debian parse result mismatch" || return 1
+    return 0
+}
+
+test-cli-parse-macos() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" parse "macos14-arm64")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "macos 14 arm64" "$result" "macOS parse result mismatch" || return 1
+    return 0
+}
+
+test-cli-parse-windows() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" parse "win64")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "win 64" "$result" "Windows parse result mismatch" || return 1
+    return 0
+}
+
+test-cli-parse-extract-os-name() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" parse "ubuntu20.04-x86_64" --os-name)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "ubuntu" "$result" "OS name extraction mismatch" || return 1
+    return 0
+}
+
+test-cli-parse-extract-os-version() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" parse "ubuntu20.04-x86_64" --os-version)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "20.04" "$result" "OS version extraction mismatch" || return 1
+    return 0
+}
+
+test-cli-parse-extract-os-arch() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" parse "ubuntu20.04-x86_64" --os-arch)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "x86_64" "$result" "OS arch extraction mismatch" || return 1
+    return 0
+}
+
+test-cli-parse-invalid() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" parse "invalid-platform" 2>&1)
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "parse should fail for invalid platform" || return 1
+    return 0
+}
+
+test-cli-extract-os-name() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" extract "debian11-arm64" --os-name)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "extract should succeed" || return 1
+    daq_assert_equals "debian" "$result" "Extract OS name mismatch" || return 1
+    return 0
+}
+
+test-cli-extract-multiple-components() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" extract "macos14-arm64" --os-name --os-arch)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "extract should succeed" || return 1
+    daq_assert_contains "macos" "$result" "Should contain OS name" || return 1
+    daq_assert_contains "arm64" "$result" "Should contain architecture" || return 1
+    return 0
+}
+
+test-cli-compose-ubuntu() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" compose --os-name ubuntu --os-version 20.04 --os-arch x86_64)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "ubuntu20.04-x86_64" "$result" "Ubuntu compose result mismatch" || return 1
+    return 0
+}
+
+test-cli-compose-debian() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" compose --os-name debian --os-version 11 --os-arch arm64)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "debian11-arm64" "$result" "Debian compose result mismatch" || return 1
+    return 0
+}
+
+test-cli-compose-macos() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" compose --os-name macos --os-version 14 --os-arch arm64)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "macos14-arm64" "$result" "macOS compose result mismatch" || return 1
+    return 0
+}
+
+test-cli-compose-windows() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" compose --os-name win --os-arch 64)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "win64" "$result" "Windows compose result mismatch" || return 1
+    return 0
+}
+
+test-cli-compose-missing-os-name() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" compose --os-version 20.04 --os-arch x86_64 2>&1)
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "compose should fail without os-name" || return 1
+    return 0
+}
+
+test-cli-compose-missing-os-arch() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" compose --os-name ubuntu --os-version 20.04 2>&1)
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "compose should fail without os-arch" || return 1
+    return 0
+}
+
+test-cli-compose-invalid-combination() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" compose --os-name ubuntu --os-version 99.99 --os-arch x86_64 2>&1)
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "compose should fail for invalid version" || return 1
+    return 0
+}
+
+test-cli-list-platforms() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" --list-platforms)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "list-platforms should succeed" || return 1
+    daq_assert_not_empty "$result" "Should return platforms" || return 1
+    return 0
+}
+
+test-cli-list-platforms-contains-ubuntu() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" --list-platforms)
+    
+    daq_assert_contains "ubuntu20.04-x86_64" "$result" "Should contain Ubuntu" || return 1
+    return 0
+}
+
+test-cli-list-platforms-contains-windows() {
+    local result
+    result=$("${PLATFORM_FORMAT_CLI}" --list-platforms)
+    
+    daq_assert_contains "win64" "$result" "Should contain Windows 64-bit" || return 1
+    return 0
+}
+
+test-cli-list-platforms-count() {
+    local count
+    count=$("${PLATFORM_FORMAT_CLI}" --list-platforms | wc -l)
+    
+    # Expected: 32 platforms
+    # Ubuntu: 3 versions × 2 archs = 6
+    # Debian: 5 versions × 2 archs = 10
+    # macOS: 7 versions × 2 archs = 14
+    # Windows: 2 archs = 2
+    # Total: 32
+    daq_assert_num_equals 32 "$count" "Should have exactly 32 platforms" || return 1
+    return 0
+}

--- a/tests/shell/bash/suites/test-version-format-api.sh
+++ b/tests/shell/bash/suites/test-version-format-api.sh
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+# test-version-format-api.sh - API tests for version-format.sh public functions
+#
+# Tests all public API functions (daq_version_*):
+# - daq_version_compose
+# - daq_version_parse
+# - daq_version_validate
+# - daq_version_extract
+
+# Source the script under test
+source "${__DAQ_TESTS_SCRIPTS_DIR}/version-format.sh"
+
+test-compose-basic-release() {
+    local result
+    result=$(daq_version_compose --major 1 --minor 2 --patch 3)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "v1.2.3" "$result" "Basic release version mismatch" || return 1
+    return 0
+}
+
+test-compose-release-without-prefix() {
+    local result
+    result=$(daq_version_compose --major 1 --minor 2 --patch 3 --exclude-prefix)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "1.2.3" "$result" "Release without prefix mismatch" || return 1
+    return 0
+}
+
+test-compose-rc-with-prefix() {
+    local result
+    result=$(daq_version_compose --major 1 --minor 2 --patch 3 --suffix rc)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "v1.2.3-rc" "$result" "RC with prefix mismatch" || return 1
+    return 0
+}
+
+test-compose-rc-without-prefix() {
+    local result
+    result=$(daq_version_compose --major 1 --minor 2 --patch 3 --suffix rc --exclude-prefix)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "1.2.3-rc" "$result" "RC without prefix mismatch" || return 1
+    return 0
+}
+
+test-compose-hash-with-prefix() {
+    local result
+    result=$(daq_version_compose --major 1 --minor 2 --patch 3 --hash a1b2c3d)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "v1.2.3-a1b2c3d" "$result" "Hash with prefix mismatch" || return 1
+    return 0
+}
+
+test-compose-hash-without-prefix() {
+    local result
+    result=$(daq_version_compose --major 1 --minor 2 --patch 3 --hash a1b2c3d --exclude-prefix)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "1.2.3-a1b2c3d" "$result" "Hash without prefix mismatch" || return 1
+    return 0
+}
+
+test-compose-with-format-release() {
+    local result
+    result=$(daq_version_compose --major 1 --minor 2 --patch 3 --format "vX.YY.Z")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "v1.2.3" "$result" "Format release mismatch" || return 1
+    return 0
+}
+
+test-compose-with-format-rc() {
+    local result
+    result=$(daq_version_compose --major 1 --minor 2 --patch 3 --suffix rc --format "X.YY.Z-rc")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "1.2.3-rc" "$result" "Format RC mismatch" || return 1
+    return 0
+}
+
+test-compose-missing-major() {
+    local result
+    result=$(daq_version_compose --minor 2 --patch 3 2>&1)
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "compose should fail with missing major" || return 1
+    return 0
+}
+
+test-parse-basic-release() {
+    local result
+    result=$(daq_version_parse "v1.2.3")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "1 2 3   v" "$result" "Parsed components mismatch" || return 1
+    return 0
+}
+
+test-parse-release-without-prefix() {
+    local result
+    result=$(daq_version_parse "1.2.3")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "1 2 3   " "$result" "Parsed components without prefix mismatch" || return 1
+    return 0
+}
+
+test-parse-rc-version() {
+    local result
+    result=$(daq_version_parse "v1.2.3-rc")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "1 2 3 rc  v" "$result" "Parsed RC components mismatch" || return 1
+    return 0
+}
+
+test-parse-hash-version() {
+    local result
+    result=$(daq_version_parse "v1.2.3-a1b2c3d")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "1 2 3  a1b2c3d v" "$result" "Parsed hash components mismatch" || return 1
+    return 0
+}
+
+test-parse-extract-major() {
+    local result
+    result=$(daq_version_parse "v1.2.3" --major)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "1" "$result" "Major version mismatch" || return 1
+    return 0
+}
+
+test-parse-extract-minor() {
+    local result
+    result=$(daq_version_parse "v1.2.3" --minor)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "2" "$result" "Minor version mismatch" || return 1
+    return 0
+}
+
+test-parse-extract-patch() {
+    local result
+    result=$(daq_version_parse "v1.2.3" --patch)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "3" "$result" "Patch version mismatch" || return 1
+    return 0
+}
+
+test-parse-extract-suffix() {
+    local result
+    result=$(daq_version_parse "v1.2.3-rc" --suffix)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "rc" "$result" "Suffix mismatch" || return 1
+    return 0
+}
+
+test-parse-extract-hash() {
+    local result
+    result=$(daq_version_parse "v1.2.3-a1b2c3d" --hash)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "a1b2c3d" "$result" "Hash mismatch" || return 1
+    return 0
+}
+
+test-parse-extract-prefix() {
+    local result
+    result=$(daq_version_parse "v1.2.3" --prefix)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "v" "$result" "Prefix mismatch" || return 1
+    return 0
+}
+
+test-parse-invalid-version() {
+    local result
+    result=$(daq_version_parse "invalid-version" 2>&1)
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "parse should fail with invalid version" || return 1
+    return 0
+}
+
+test-validate-basic-release() {
+    daq_version_validate "v1.2.3" >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for basic release" || return 1
+    return 0
+}
+
+test-validate-release-without-prefix() {
+    daq_version_validate "1.2.3" >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for release without prefix" || return 1
+    return 0
+}
+
+test-validate-rc() {
+    daq_version_validate "v1.2.3-rc" >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for RC" || return 1
+    return 0
+}
+
+test-validate-hash() {
+    daq_version_validate "v1.2.3-a1b2c3d" >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for hash version" || return 1
+    return 0
+}
+
+test-validate-with-format-match() {
+    daq_version_validate "v1.2.3" --format "vX.YY.Z" >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for matching format" || return 1
+    return 0
+}
+
+test-validate-with-format-mismatch() {
+    daq_version_validate "v1.2.3" --format "X.YY.Z" >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "validate should fail for mismatching format" || return 1
+    return 0
+}
+
+test-validate-is-release-true() {
+    daq_version_validate "v1.2.3" --is-release >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for release check" || return 1
+    return 0
+}
+
+test-validate-is-release-false() {
+    daq_version_validate "v1.2.3-rc" --is-release >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "validate should fail for non-release" || return 1
+    return 0
+}
+
+test-validate-is-rc-true() {
+    daq_version_validate "v1.2.3-rc" --is-rc >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for RC check" || return 1
+    return 0
+}
+
+test-validate-is-rc-false() {
+    daq_version_validate "v1.2.3" --is-rc >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "validate should fail for non-RC" || return 1
+    return 0
+}
+
+test-validate-is-dev-true() {
+    daq_version_validate "v1.2.3-a1b2c3d" --is-dev >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for dev check" || return 1
+    return 0
+}
+
+test-validate-is-dev-false() {
+    daq_version_validate "v1.2.3" --is-dev >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "validate should fail for non-dev" || return 1
+    return 0
+}
+
+test-extract-from-filename() {
+    local result
+    result=$(daq_version_extract "opendaq-v1.2.3-ubuntu20.04-x86_64.deb")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "extract should succeed" || return 1
+    daq_assert_equals "v1.2.3" "$result" "Extracted version mismatch" || return 1
+    return 0
+}
+
+test-extract-without-prefix() {
+    local result
+    result=$(daq_version_extract "package-1.2.3.zip")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "extract should succeed" || return 1
+    daq_assert_equals "1.2.3" "$result" "Extracted version without prefix mismatch" || return 1
+    return 0
+}
+
+test-extract-rc-version() {
+    local result
+    result=$(daq_version_extract "build-v1.2.3-rc-artifact.tar")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "extract should succeed" || return 1
+    daq_assert_equals "v1.2.3-rc" "$result" "Extracted RC version mismatch" || return 1
+    return 0
+}
+
+test-extract-hash-version() {
+    local result
+    result=$(daq_version_extract "commit-v1.2.3-a1b2c3d.log")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "extract should succeed" || return 1
+    daq_assert_equals "v1.2.3-a1b2c3d" "$result" "Extracted hash version mismatch" || return 1
+    return 0
+}
+
+test-extract-multiple-versions() {
+    local result
+    result=$(daq_version_extract "v1.0.0-to-v2.0.0-migration")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "extract should succeed" || return 1
+    daq_assert_equals "v1.0.0" "$result" "Should extract first version" || return 1
+    return 0
+}
+
+test-extract-no-version() {
+    local result
+    result=$(daq_version_extract "no-version-here.txt" 2>&1)
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "extract should fail when no version found" || return 1
+    return 0
+}

--- a/tests/shell/bash/suites/test-version-format-cli.sh
+++ b/tests/shell/bash/suites/test-version-format-cli.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# test-version-format-cli.sh - CLI tests for version-format.sh
+#
+# Tests the command-line interface of version-format.sh:
+# - Help and usage
+# - compose command
+# - parse command
+# - validate command
+# - extract command
+
+# CLI script path
+VERSION_FORMAT_CLI="${__DAQ_TESTS_SCRIPTS_DIR}/version-format.sh"
+
+test-cli-help-flag() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" --help 2>&1)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "help should succeed" || return 1
+    daq_assert_contains "Usage:" "$result" "Help should contain usage" || return 1
+    return 0
+}
+
+test-cli-no-arguments() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" 2>&1)
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "no arguments should fail" || return 1
+    daq_assert_contains "Usage:" "$result" "Should show usage on error" || return 1
+    return 0
+}
+
+test-cli-compose-basic() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" compose --major 1 --minor 2 --patch 3)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "v1.2.3" "$result" "Basic compose result mismatch" || return 1
+    return 0
+}
+
+test-cli-compose-with-rc() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" compose --major 1 --minor 2 --patch 3 --suffix rc)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "v1.2.3-rc" "$result" "RC compose result mismatch" || return 1
+    return 0
+}
+
+test-cli-compose-with-hash() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" compose --major 1 --minor 2 --patch 3 --hash a1b2c3d)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "v1.2.3-a1b2c3d" "$result" "Hash compose result mismatch" || return 1
+    return 0
+}
+
+test-cli-compose-exclude-prefix() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" compose --major 1 --minor 2 --patch 3 --exclude-prefix)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "1.2.3" "$result" "Compose without prefix result mismatch" || return 1
+    return 0
+}
+
+test-cli-compose-missing-required() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" compose --major 1 2>&1)
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "compose should fail with missing arguments" || return 1
+    return 0
+}
+
+test-cli-compose-invalid-suffix() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" compose --major 1 --minor 2 --patch 3 --suffix invalid 2>&1)
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "compose should fail with invalid suffix" || return 1
+    return 0
+}
+
+test-cli-compose-with-format() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" compose --major 1 --minor 2 --patch 3 --format "X.YY.Z")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "compose should succeed" || return 1
+    daq_assert_equals "1.2.3" "$result" "Format compose result mismatch" || return 1
+    return 0
+}
+
+test-cli-parse-basic() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" parse v1.2.3)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "1 2 3   v" "$result" "Parse result mismatch" || return 1
+    return 0
+}
+
+test-cli-parse-extract-major() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" parse v1.2.3 --major)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "1" "$result" "Major parse result mismatch" || return 1
+    return 0
+}
+
+test-cli-parse-extract-minor() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" parse v1.2.3 --minor)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "2" "$result" "Minor parse result mismatch" || return 1
+    return 0
+}
+
+test-cli-parse-extract-patch() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" parse v1.2.3 --patch)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "3" "$result" "Patch parse result mismatch" || return 1
+    return 0
+}
+
+test-cli-parse-rc-version() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" parse v1.2.3-rc --suffix)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "rc" "$result" "RC suffix parse result mismatch" || return 1
+    return 0
+}
+
+test-cli-parse-hash-version() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" parse v1.2.3-a1b2c3d --hash)
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "parse should succeed" || return 1
+    daq_assert_equals "a1b2c3d" "$result" "Hash parse result mismatch" || return 1
+    return 0
+}
+
+test-cli-parse-invalid() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" parse invalid 2>&1)
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "parse should fail with invalid version" || return 1
+    return 0
+}
+
+test-cli-validate-valid() {
+    "${VERSION_FORMAT_CLI}" validate v1.2.3 >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for valid version" || return 1
+    return 0
+}
+
+test-cli-validate-invalid() {
+    "${VERSION_FORMAT_CLI}" validate not-valid >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "validate should fail for invalid version" || return 1
+    return 0
+}
+
+test-cli-validate-with-format-match() {
+    "${VERSION_FORMAT_CLI}" validate v1.2.3 --format "vX.YY.Z" >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for matching format" || return 1
+    return 0
+}
+
+test-cli-validate-with-format-mismatch() {
+    "${VERSION_FORMAT_CLI}" validate v1.2.3 --format "X.YY.Z" >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "validate should fail for mismatching format" || return 1
+    return 0
+}
+
+test-cli-validate-is-release() {
+    "${VERSION_FORMAT_CLI}" validate v1.2.3 --is-release >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for release" || return 1
+    return 0
+}
+
+test-cli-validate-is-rc-true() {
+    "${VERSION_FORMAT_CLI}" validate v1.2.3-rc --is-rc >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for RC" || return 1
+    return 0
+}
+
+test-cli-validate-is-dev-true() {
+    "${VERSION_FORMAT_CLI}" validate v1.2.3-a1b2c3d --is-dev >/dev/null 2>&1
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "validate should succeed for dev version" || return 1
+    return 0
+}
+
+test-cli-extract-from-text() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" extract "opendaq-v1.2.3-linux.tar.gz")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "extract should succeed" || return 1
+    daq_assert_equals "v1.2.3" "$result" "Extract result mismatch" || return 1
+    return 0
+}
+
+test-cli-extract-no-version() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" extract "no-version.txt" 2>&1)
+    local exit_code=$?
+    
+    daq_assert_failure $exit_code "extract should fail when no version" || return 1
+    return 0
+}
+
+test-cli-extract-rc() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" extract "opendaq-v1.2.3-rc-ubuntu20.04-x86_64.deb")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "extract should succeed" || return 1
+    daq_assert_equals "v1.2.3-rc" "$result" "RC extract result mismatch" || return 1
+    return 0
+}
+
+test-cli-extract-hash() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" extract "opendaq-v1.2.3-a1b2c3d-ubuntu20.04-x86_64.deb")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "extract should succeed" || return 1
+    daq_assert_equals "v1.2.3-a1b2c3d" "$result" "Hash extract result mismatch" || return 1
+    return 0
+}
+
+test-cli-extract-multiple-versions() {
+    local result
+    result=$("${VERSION_FORMAT_CLI}" extract "v1.2.3-to-v5.6.7")
+    local exit_code=$?
+    
+    daq_assert_success $exit_code "extract should succeed" || return 1
+    daq_assert_equals "v1.2.3" "$result" "Should extract first version" || return 1
+    return 0
+}


### PR DESCRIPTION
Add new GitHub Action for installing openDAQ framework packages on Windows and Linux runners. The action accepts a full path to the package file and handles platform-specific installation.
- Depends on #9 

Features:
- Windows: Silent installation via .exe with PATH configuration
- Linux: Installation via dpkg for .deb packages
- Error handling and exit code validation
- Comprehensive documentation with multiple usage examples

Input parameters:
- framework-filename: Full path to openDAQ package file
  (e.g., opendaq-v3.20.4-ubuntu20.04-x86_64.deb)

Supported platforms:
- Windows (via .exe installer)
- Linux (via .deb package)